### PR TITLE
Address npm production config warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node main.js",
     "dev": "nodemon main.js",
-    "install-deps": "npm install"
+    "install-deps": "npm install",
+    "install-prod": "npm ci --omit=dev"
   },
   "author": "Tim Moss",
   "license": "MIT",


### PR DESCRIPTION
Add `install-prod` script to `package.json` to use `npm ci --omit=dev` and address the deprecated `--production` flag warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ac49a38-5da4-46f1-b3bb-04b8bc47a930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ac49a38-5da4-46f1-b3bb-04b8bc47a930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

